### PR TITLE
Add sample Google search API

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,21 @@ npm run build
 npm test
 ```
 
+## API Server
+
+An example HTTP API is provided in `server.js`. Start it with:
+
+```sh
+npm start
+```
+
+Query the `/search` endpoint with a `q` parameter to fetch the title of the first
+Google search result. For example:
+
+```
+curl "http://localhost:3000/search?q=nodejs"
+```
+
 ## Continuous Integration
 
 A GitHub Actions workflow is provided in `.github/workflows/nodejs.yml` which runs the build and tests on Node.js 18.x and 20.x whenever changes are pushed or a pull request is opened.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "build": "node index.js",
-    "test": "node test/test.js"
+    "test": "node test/test.js",
+    "start": "node server.js"
   },
   "keywords": [],
   "author": "",

--- a/server.js
+++ b/server.js
@@ -1,0 +1,59 @@
+const http = require('http');
+const https = require('https');
+const { URL } = require('url');
+
+function fetchGoogle(query) {
+  return new Promise((resolve, reject) => {
+    const options = {
+      hostname: 'www.google.com',
+      path: '/search?q=' + encodeURIComponent(query),
+      headers: { 'User-Agent': 'Mozilla/5.0' }
+    };
+    https.get(options, res => {
+      let data = '';
+      res.on('data', chunk => {
+        data += chunk.toString();
+      });
+      res.on('end', () => resolve(data));
+    }).on('error', reject);
+  });
+}
+
+function extractFirstTitle(html) {
+  const match = html.match(/<h3[^>]*>(.*?)<\/h3>/i);
+  if (match) {
+    return match[1].replace(/<[^>]*>/g, '').trim();
+  }
+  return '';
+}
+
+const port = process.env.PORT || 3000;
+
+const server = http.createServer(async (req, res) => {
+  const url = new URL(req.url, `http://${req.headers.host}`);
+  if (url.pathname === '/search') {
+    const q = url.searchParams.get('q');
+    if (!q) {
+      res.writeHead(400, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'Missing q parameter' }));
+      return;
+    }
+    try {
+      const html = await fetchGoogle(q);
+      const title = extractFirstTitle(html);
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ title }));
+    } catch (err) {
+      console.error(err);
+      res.writeHead(500, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'Failed to fetch results' }));
+    }
+  } else {
+    res.writeHead(404, { 'Content-Type': 'text/plain' });
+    res.end('Not Found');
+  }
+});
+
+server.listen(port, () => {
+  console.log(`Server listening on port ${port}`);
+});


### PR DESCRIPTION
## Summary
- add a simple HTTP server in `server.js`
- document how to run the API in README
- expose `npm start` script

## Testing
- `npm run build`
- `npm test`
