### PR TITLE
Add endpoint to fetch blog titles

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,13 @@ Google search result. For example:
 curl "http://localhost:3000/search?q=nodejs"
 ```
 
+You can also fetch all blog post titles from [rcelebrone.com](https://www.rcelebrone.com)
+by querying the `/search-rcelebrone` endpoint:
+
+```
+curl "http://localhost:3000/search-rcelebrone?q=Arquitetura"
+```
+
 ## Continuous Integration
 
 A GitHub Actions workflow is provided in `.github/workflows/nodejs.yml` which runs the build and tests on Node.js 18.x and 20.x whenever changes are pushed or a pull request is opened.

--- a/index.js
+++ b/index.js
@@ -27,12 +27,42 @@ function fetchGoogle(query) {
   });
 }
 
+function fetchRcelebrone(query) {
+  return new Promise((resolve, reject) => {
+    const options = {
+      hostname: 'www.rcelebrone.com',
+      path: '/search?q=' + encodeURIComponent(query),
+      headers: { 'User-Agent': 'Mozilla/5.0' }
+    };
+    https.get(options, res => {
+      let data = '';
+      res.on('data', chunk => {
+        data += chunk.toString();
+      });
+      res.on('end', () => resolve(data));
+    }).on('error', reject);
+  });
+}
+
 function extractFirstTitle(html) {
   const match = html.match(/<h3[^>]*>(.*?)<\/h3>/i);
   if (match) {
     return match[1].replace(/<[^>]*>/g, '').trim();
   }
   return '';
+}
+
+function extractTitles(html) {
+  const regex = /<h3[^>]*>(.*?)<\/h3>/gi;
+  const titles = [];
+  let match;
+  while ((match = regex.exec(html)) !== null) {
+    const text = match[1].replace(/<[^>]*>/g, '').trim();
+    if (text) {
+      titles.push(text);
+    }
+  }
+  return titles;
 }
 
 function add(a, b) {
@@ -58,6 +88,22 @@ app.get('/search', async (req, res) => {
   }
 });
 
+app.get('/search-rcelebrone', async (req, res) => {
+  const q = req.query.q;
+  if (!q) {
+    res.status(400).json({ error: 'Missing q parameter' });
+    return;
+  }
+  try {
+    const html = await fetchRcelebrone(q);
+    const titles = extractTitles(html);
+    res.json({ titles });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to fetch results' });
+  }
+});
+
 if (require.main === module) {
   app.listen(port, () => {
     console.log(`Server listening on port ${port}`);
@@ -68,6 +114,8 @@ if (require.main === module) {
 module.exports = {
   add,
   fetchGoogle,
+  fetchRcelebrone,
   extractFirstTitle,
+  extractTitles,
   app,
 };

--- a/test/test.js
+++ b/test/test.js
@@ -1,5 +1,5 @@
 const assert = require('assert');
-const { add, extractFirstTitle } = require('../index');
+const { add, extractFirstTitle, extractTitles } = require('../index');
 
 assert.strictEqual(add(2, 3), 5);
 
@@ -21,4 +21,13 @@ const sampleHtml = `
 `;
 
 assert.strictEqual(extractFirstTitle(sampleHtml), 'Expected Title');
+
+const multiHtml = `
+<div>
+  <h3>Title One</h3>
+  <p>something</p>
+  <h3>Title Two</h3>
+</div>
+`;
+assert.deepStrictEqual(extractTitles(multiHtml), ['Title One', 'Title Two']);
 console.log('All tests passed');


### PR DESCRIPTION
## Summary
- add a function to fetch pages from rcelebrone.com
- scrape all `<h3>` titles with `extractTitles`
- expose a new `/search-rcelebrone` endpoint
- document new endpoint in README
- test new title extraction

## Testing
- `npm test`